### PR TITLE
Bump version for first release tag

### DIFF
--- a/MultiHMCGibbs/__init__.py
+++ b/MultiHMCGibbs/__init__.py
@@ -5,4 +5,4 @@
 
 from .multihmcgibbs import MultiHMCGibbs  # noqa: F401
 
-__version__ = '0.1.0'
+__version__ = '1.0.0'

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -16,7 +16,7 @@ sys.path.insert(0, os.path.abspath('../..'))
 project = 'MultiHMCGibbs'
 copyright = '2024, Coleman Krawczyk'
 author = 'Coleman Krawczyk'
-release = '0.1.0'
+release = '1.0.0'
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration


### PR DESCRIPTION
Change to version 1.0.0 in preparation for the first release tag.